### PR TITLE
Publish Space Travel on GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,43 @@
+name: Deploy Space Travel to Pages
+
+on:
+  push:
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Setup emsdk
+        uses: mymindstorm/setup-emsdk@v14
+      - name: Build Space Travel
+        run: emcc st.c -s USE_SDL=2 -o html/st.js
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: 'html'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/html/index.html
+++ b/html/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>C port of Ken Thompson's Space Travel</title>
+    <style>
+    html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        background-color: black;
+    }
+    canvas {
+      display: block;
+      max-width: calc(100% - 40px);
+      max-height: calc(100% - 40px);
+      object-fit: contain;
+      margin: 20px;
+    }
+    </style>
+</head>
+<body>
+    <canvas id="canvas" oncontextmenu="event.preventDefault()"></canvas>
+    <script>
+        var Module = {
+            canvas: (function() { return document.getElementById('canvas'); })()
+        };
+    </script>
+    <script src="st.js"></script>
+</body>
+</html>


### PR DESCRIPTION
This PR will publish Space Travel on GitHub Pages.

It seems that `Build and dployment > Source` in https://github.com/mohd-akram/st/settings/pages needs to be switched to `GitHub Actions` before merging. Temporarily published at https://ko1nksm.github.io/st/ for the purpose of review.

If this PR merge is successful, Space Travel should automatically be published at https://mohd-akram.github.io/st/.
